### PR TITLE
server: interceptors (middleware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,97 @@
 # grpcx
 
 Ruby gRPC extensions/helpers
+
+
+# Grpcx::Server
+
+Mixin for `GRPC::RpcServer`:
+
+- handles [GRPC health checks](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) requests
+- transforms most common `ActiveRecord::ActiveRecordError`-s into `GRPC::BadStatus` ones
+- handles `ActiveRecord` connection (auto-connect + pooling)
+- instruments each request with `ActiveSupport::Notifications` (available as `process_action.grpc`, includes `action: METHOD_NAME` data)
+
+Example:
+
+```ruby
+require 'grpcx/server' # or just 'grpcx'
+
+class MyServer << GRPC::RpcServer
+  include Grpcx::Server
+end
+
+# proceed as with usual GRPC::RpcServer:
+server = MyServer.new(...)
+server.handle(MyService.new)
+server.add_http2_port '127.0.0.1:8080', :this_port_is_insecure
+server.run_till_terminated
+```
+
+Recommended to be used with [Grpclb::Server](https://github.com/bsm/grpclb/tree/master/ruby):
+
+```ruby
+require 'grpclb/server'
+require 'grpcx/server'
+
+class MyServer << Grpclb::Server
+  include Grpcx::Server
+end
+
+...
+```
+
+
+## Using with [Datadog::Notifications](https://github.com/bsm/datadog-notifications)
+
+```ruby
+module Datadog::Notifications::Plugins
+  class GRPC < Base
+
+    def initialize(opts={})
+      super
+      Datadog::Notifications.subscribe 'process_action.grpc' do |reporter, event|
+        record(reporter, event)
+      end
+    end
+
+    private
+
+    def record(reporter, event)
+      action = event.payload[:action]
+      status = event.payload[:exception] ? 'error' : 'ok'
+      tags = self.tags + ["rpc:#{action}", "status:#{status}"]
+
+      reporter.batch do
+        reporter.increment 'grpc.request', tags: tags
+        reporter.timing 'grpc.request.time', event.duration, tags: tags
+      end
+    end
+
+  end
+end
+
+Datadog::Notifications.configure do |c|
+  c.use Datadog::Notifications::Plugins::GRPC
+end if RUNNING_IN_PROD?
+```
+
+
+## Using with [Sentry](https://sentry.io/)/[Raven](https://github.com/getsentry/raven-ruby)
+
+```ruby
+ActiveSupport::Notifications.subscribe('process_action.grpc') do |_name, _start, _finish, _id, payload|
+  e = payload[:exception_object]
+  next unless e
+
+  Raven.capture_exception(e)
+end
+
+Raven.configure do |config|
+  config.should_capture = proc {|e|
+    !e.is_a?(GRPC::BadStatus) # skip GRPC::BadStatus, but report everything else
+  }
+end
+```
+
+Similar approach can be used for logging.

--- a/grpcx.gemspec
+++ b/grpcx.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'grpcx'
-  s.version       = '0.0.1'
+  s.version       = '0.0.2'
   s.authors       = ['Black Square Media Ltd']
   s.email         = ['info@blacksquaremedia.com']
   s.summary       = %(gRPC extensions/helpers)
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.2'
 
-  s.add_dependency 'grpc'
+  s.add_dependency 'grpc' # TODO: investigate which version is compatible (like when interceptors were introduced)
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'

--- a/lib/grpcx/server.rb
+++ b/lib/grpcx/server.rb
@@ -1,16 +1,15 @@
 require 'grpc/health/checker'
 
+require 'grpcx/server/interceptor/active_record/errors'
+require 'grpcx/server/interceptor/active_record/connection'
+require 'grpcx/server/interceptor/active_support/notifications/instrument'
+
 module Grpcx
   module Server
     module Methods
       def initialize(opts={})
         @checker = ::Grpc::Health::Checker.new
-
-        opts[:pool_size] ||= ENV['GRPC_SERVER_THREADS'].to_i if ENV['GRPC_SERVER_THREADS']
-        opts[:max_waiting_requests] ||= ENV['GRPC_SERVER_QUEUE'].to_i if ENV['GRPC_SERVER_QUEUE']
-
-        super(opts)
-
+        super(apply_default_options(opts))
         handle(@checker)
       end
 
@@ -21,6 +20,29 @@ module Grpcx
         @checker.add_status(service.service_name, ::Grpc::Health::Checker::HealthCheckResponse::ServingStatus::SERVING)
 
         super(service)
+      end
+
+      private
+
+      def apply_default_options(opts={})
+        opts.tap do
+          opts[:pool_size] ||= ENV['GRPC_SERVER_THREADS'].to_i if ENV['GRPC_SERVER_THREADS']
+          opts[:max_waiting_requests] ||= ENV['GRPC_SERVER_QUEUE'].to_i if ENV['GRPC_SERVER_QUEUE']
+
+          # interceptors are fired in FIFO order,
+          # so more generic handlers come last:
+          (opts[:interceptors] ||= []).concat(default_interceptors)
+        end
+      end
+
+      def default_interceptors
+        # this could be a const array, as we don't rely on any options to init interceptors (yet),
+        # but it's fine to leave as-is for now:
+        [
+          Grpcx::Server::Interceptor::ActiveRecord::Errors.new,
+          Grpcx::Server::Interceptor::ActiveRecord::Connection.new,
+          Grpcx::Server::Interceptor::ActiveSupport::Notifications::Instrument.new,
+        ]
       end
     end
     private_constant :Methods

--- a/lib/grpcx/server/interceptor/active_record/connection.rb
+++ b/lib/grpcx/server/interceptor/active_record/connection.rb
@@ -1,0 +1,39 @@
+module Grpcx
+  module Server
+    module Interceptor
+      module ActiveRecord
+        # Manages ActiveRecord::Base connection,
+        # like making sure that connection is established before each request
+        # and re-pooling connections when request is processed.
+        class Connection < GRPC::ServerInterceptor
+
+          def bidi_streamer(_requests: nil, _call: nil, _method: nil, &block)
+            wrap(&block)
+          end
+
+          def client_streamer(_call: nil, _method: nil, &block)
+            wrap(&block)
+          end
+
+          def request_response(_request: nil, _call: nil, _method: nil, &block)
+            wrap(&block)
+          end
+
+          def server_streamer(_request: nil, _call: nil, _method: nil, &block)
+            wrap(&block)
+          end
+
+          private
+
+          def wrap
+            ::ActiveRecord::Base.establish_connection unless ::ActiveRecord::Base.connection.active?
+            yield
+          ensure
+            ::ActiveRecord::Base.clear_active_connections!
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/grpcx/server/interceptor/active_record/errors.rb
+++ b/lib/grpcx/server/interceptor/active_record/errors.rb
@@ -1,0 +1,39 @@
+module Grpcx
+  module Server
+    module Interceptor
+      module ActiveRecord
+        # Intercepts most common ActiveRecord::ActiveRecordError-s
+        # and transforms them into corresponding GRPC::BadStatus ones.
+        class Errors < GRPC::ServerInterceptor
+
+          def bidi_streamer(_requests: nil, _call: nil, _method: nil, &block)
+            wrap(&block)
+          end
+
+          def client_streamer(_call: nil, _method: nil, &block)
+            wrap(&block)
+          end
+
+          def request_response(_request: nil, _call: nil, _method: nil, &block)
+            wrap(&block)
+          end
+
+          def server_streamer(_request: nil, _call: nil, _method: nil, &block)
+            wrap(&block)
+          end
+
+          private
+
+          def wrap
+            yield
+          rescue ActiveRecord::RecordInvalid => e
+            raise GRPC::InvalidArgument.new(errors: e.record.errors.to_h)
+          rescue ActiveRecord::RecordNotFound => e
+            raise GRPC::NotFound.new(id: e.id, model: e.model.to_s)
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/grpcx/server/interceptor/active_support/notifications/instrument.rb
+++ b/lib/grpcx/server/interceptor/active_support/notifications/instrument.rb
@@ -1,0 +1,43 @@
+# TODO: this interceptor is kind of easily testable,
+#       worth having a test in future.
+
+module Grpcx
+  module Server
+    module Interceptor
+      module ActiveSupport
+        module Notifications
+          # Instruments each request with ActiveSupport::Notifications.
+          class Instrument < GRPC::ServerInterceptor
+            METRIC_NAME = 'process_action.grpc'.freeze
+
+            def bidi_streamer(_requests: nil, _call: nil, meth: nil, &block)
+              # TODO: at some point would be nice to wrap streamers and report stats like messages received/sent
+              wrap(action: meth, &block)
+            end
+
+            def client_streamer(_call: nil, meth: nil, &block)
+              # TODO: at some point would be nice to wrap streamers and report stats like messages received
+              wrap(action: meth, &block)
+            end
+
+            def request_response(_request: nil, _call: nil, meth: nil, &block)
+              wrap(action: meth, &block)
+            end
+
+            def server_streamer(_request: nil, _call: nil, meth: nil, &block)
+              # TODO: at some point would be nice to wrap streamers and report stats like messages sent
+              wrap(action: meth, &block)
+            end
+
+            private
+
+            def wrap(opts={}, &block)
+              ActiveSupport::Notifications.instrument(METRIC_NAME, opts, &block)
+            end
+
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There's no need for fancy service wrappers/mixing, gRPC server interceptors seems to do everything that's needed.